### PR TITLE
Add compact score updates functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A discord bot for blaseball
 * Team lookup (`bb!team [team name, nickname, or emoji]`)
 * Game subscription (`bb!subscribe [team]`)
 * Game summaries (`bb!summarize [team]`)
+* Game score updates (`bb!scores [team]`)
+* Game score updates compact mode (`bb!compact [team]`)
 
 ## Game Subscription
 
@@ -17,6 +19,10 @@ Game subscription allows you to have plays and score for all games a team play s
 ## Game Summaries
 
 Game summaries are similar to subscriptions. When a game ends, a score card will be sent to the selected channel, this is the same card generated with game lookups. Unlike subscriptions, you may have multiple teams summaries sent to the same channel. You can subscribe to summaries using `bb!summarize [team]` and unsubscribe with `bb!unsummarize [team]`.
+
+## Game Scores
+
+Game scores are also similar to subscriptions, only giving updates on scoring plays. You can subscribe to score updates using `bb!scores [team]` and unsubscribe with `bb!unscores [team]`. If you want a more compact version, use `bb!compact[team]` and `bb!uncompact[team]`.
 
 ## Privacy
 

--- a/bot/commands/compact.js
+++ b/bot/commands/compact.js
@@ -1,0 +1,32 @@
+const { getTeam } = require("../util/teamUtils");
+const {compacts} = require("../schemas/subscription");
+const { messageError } = require("../util/miscUtils");
+
+const command = {
+    name: "compact",
+    aliases: ["update-compact","score-compact","small"],
+    description: "Subscribes a channel to a teams compact game scores\nThe bot will update the channel whenever score changes\nA guild is only allowed one score tracking of each team, but unlike subscripitions they can share a channel\nbb!compact [team name]",
+    async execute(message, args) {
+
+        if(message.guild && !message.channel.permissionsFor(message.member).has("MANAGE_CHANNELS")) return message.channel.send("You require the manage channel permission to run this command!").then(global.stats.messageFreq.mark()).catch(messageError);
+
+        let team = await getTeam(args.join(" "));
+        if(!team) return message.channel.send("I can't find that team!").then(global.stats.messageFreq.mark()).catch(messageError);
+
+        let err, docs = await compacts.find({$or: [{channel_id: message.channel.id},{guild_id:message.guild?.id??message.channel.id, team:team.id}]});
+        if(err) throw err;
+        if(docs.length > 0) return message.channel.send("You already have subscibed to this teams compact score updates! use bb!uncompact to remove the summaries").then(global.stats.messageFreq.mark()).catch(messageError);
+
+        // eslint-disable-next-line no-unused-vars
+        let savErr, doc = new compacts({
+            channel_id: message.channel.id,
+            guild_id: message.guild?.id??message.channel.id,
+            team: team.id
+        }).save();
+        if(savErr) throw savErr;
+        return message.channel.send(`Subscribed this channel to the ${team.nickname}'s compact score updates!`).then(global.stats.messageFreq.mark()).catch(messageError);
+
+    },
+};
+
+module.exports = command;

--- a/bot/commands/help.js
+++ b/bot/commands/help.js
@@ -1,5 +1,4 @@
 const { messageError } = require("../util/miscUtils");
-const io = require("@pm2/io");
 
 const command = {
     name: "help",

--- a/bot/commands/score.js
+++ b/bot/commands/score.js
@@ -4,7 +4,7 @@ const { messageError } = require("../util/miscUtils");
 
 const command = {
     name: "updates",
-    aliases: ["update"],
+    aliases: ["update","scores"],
     description: "Subscribes a channel to a teams game scores\nThe bot will update the channel whenever score changes\nA guild is only allowed one score tracking of each team, but unlike subscripitions they can share a channel\nbb!scores [team name]",
     async execute(message, args) {
 

--- a/bot/commands/subscribe.js
+++ b/bot/commands/subscribe.js
@@ -4,7 +4,7 @@ const { messageError } = require("../util/miscUtils");
 
 const command = {
     name: "subscribe",
-    aliases: ["play-by-play","sub"],
+    aliases: ["play-by-play","sub","pbp"],
     description: "Subscribes a channel to a teams games\nA guild can only have one channel per team at max, and one team per channel.\nbb!subscribe [team name]",
     async execute(message, args) {
 
@@ -15,7 +15,7 @@ const command = {
 
         let err, docs = await subscriptions.find({$or: [{channel_id: message.channel.id},{guild_id:message.guild?.id??message.channel.id, team:team.id}]});
         if(err) throw err;
-        if(docs.length > 0) return message.channel.send("You already have subscibed this channel to a team, or this team to a channel! use bb!unsubscibre to remove the subscription").then(global.stats.messageFreq.mark()).catch(messageError);
+        if(docs.length > 0) return message.channel.send("You already have subscibed this channel to a team, or this team to a channel! use bb!unsubscribe to remove the subscription").then(global.stats.messageFreq.mark()).catch(messageError);
 
         // eslint-disable-next-line no-unused-vars
         let savErr, doc = new subscriptions({

--- a/bot/commands/uncompact.js
+++ b/bot/commands/uncompact.js
@@ -1,11 +1,11 @@
 const { getTeam } = require("../util/teamUtils");
-const {scores} = require("../schemas/subscription");
+const {compacts} = require("../schemas/subscription");
 const { messageError } = require("../util/miscUtils");
 
 const command = {
-    name: "unscore",
+    name: "uncompact",
     aliases: [],
-    description: "Unsubscribes from the score updates of a channel\nbb!unscore [team]",
+    description: "Unsubscribes from the score updates of a channel\nbb!uncompact [team]",
     async execute(message, args) {
 
         if(message.guild && !message.channel.permissionsFor(message.member).has("MANAGE_CHANNELS")) return message.channel.send("You require the manage channel permission to run this command!").then(global.stats.messageFreq.mark()).catch(messageError);
@@ -13,15 +13,15 @@ const command = {
         let team = await getTeam(args.join(" "));
         if(!team) return message.channel.send("I can't find that team!").then(global.stats.messageFreq.mark()).catch(messageError);
 
-        let err, docs = await scores.find({channel_id: message.channel.id, team:team.id});
+        let err, docs = await compacts.find({channel_id: message.channel.id, team:team.id});
         if(err) throw err;
-        if(docs.length == 0) return message.channel.send(`You are not subscribed to ${team.fullName}'s score updates here!`).then(global.stats.messageFreq.mark()).catch(messageError);
+        if(docs.length == 0) return message.channel.send(`You are not subscribed to ${team.fullName}'s compact score updates here!`).then(global.stats.messageFreq.mark()).catch(messageError);
 
         // eslint-disable-next-line no-unused-vars
-        let error, doc = await scores.deleteOne({channel_id: message.channel.id, team:team.id});
+        let error, doc = await compacts.deleteOne({channel_id: message.channel.id, team:team.id});
         if(error) throw error;
 
-        message.channel.send(`Unsubscribed this channel from ${team.fullName}'s score updates here!!`).then(global.stats.messageFreq.mark()).catch(messageError);
+        message.channel.send(`Unsubscribed this channel from ${team.fullName}'s compact score updates here!!`).then(global.stats.messageFreq.mark()).catch(messageError);
 
     },
 };

--- a/bot/schemas/subscription.js
+++ b/bot/schemas/subscription.js
@@ -19,6 +19,12 @@ let score = new Mongoose.Schema({
     team: String
 });
 
+let compact = new Mongoose.Schema({
+    channel_id: String,
+    guild_id: String,
+    team: String
+});
+
 let bet = new Mongoose.Schema({
     channel_id: String
 });
@@ -29,5 +35,6 @@ module.exports = {
     subscriptions: Mongoose.model("subscriptions",subscription),
     summaries: Mongoose.model("summaries", summary),
     scores: Mongoose.model("scores",score),
+    compacts: Mongoose.model("compacts", compact),
     betReminders: Mongoose.model("bets",bet)
 };


### PR DESCRIPTION
- Adds `bb!compact [team]` and `bb!uncompact [team]` to blasebot
- A few minor bugfixes, primarily around making sure help text matches the commands offered

Over in the Lovers channel, we were really enjoying the score updates but were finding that they took a bit too much screen real estate, especially on mobile. After we all had a good chat on Discord, this is the solution we came up with.

![image](https://user-images.githubusercontent.com/6749550/92508234-2bfacd00-f200-11ea-9961-614e49c1a381.png)
