### PR TITLE
Update player/team cards for S12-16, update events for S16

### DIFF
--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -417,6 +417,8 @@ const eventTypes = [
     {id: "BIRD", name: "Birds", colour: "#8e5fad", search: /birds/i},
     {id: "BLACKHOLE", name: "Black Hole", colour: "#00374a", search: /black hole/i},
     {id: "SUN2", name: "Sun 2", colour: "#fdff9c", search: /sun 2/i},
+    {id: "SALMON", name: "Salmon", colour: "#ba7b97", search: /salmon/i},
+    {id: "GLITTER", name: "Glitter", colour: "#fff98a", search: /gained/i},
 
     {id: "UNSTABLE", name: "Unstable", colour: "#eaabff", search: /unstable|instability /i},
     {id: "PARTY", name: "Party Time", colour: "#ff66f9", search: /party/i},

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -418,7 +418,7 @@ const eventTypes = [
     {id: "BLACKHOLE", name: "Black Hole", colour: "#00374a", search: /black hole/i},
     {id: "SUN2", name: "Sun 2", colour: "#fdff9c", search: /sun 2/i},
     {id: "SALMON", name: "Salmon", colour: "#ba7b97", search: /salmon/i},
-    {id: "GLITTER", name: "Glitter", colour: "#fff98a", search: /gained/i},
+    {id: "GLITTER", name: "Glitter", colour: "#ff94ff", search: /gained/i},
 
     {id: "UNSTABLE", name: "Unstable", colour: "#eaabff", search: /unstable|instability /i},
     {id: "PARTY", name: "Party Time", colour: "#ff66f9", search: /party/i},

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -409,6 +409,7 @@ const {MessageEmbed} = require("discord.js");
 // }
 
 const eventTypes = [
+    // Note: if multiple matches are made, only the *last* one will be used
     {id: "REVERB", name: "Reverb", colour: "#5c407d", search: /reverb|repeat/i},
     {id: "FEEDBACK", name: "Feedback", colour: "#ff007b", search: /flicker|feedback/i},
     {id: "INCINERATION", name: "Incineration", colour: "#fefefe", search: /rogue umpire/i},
@@ -429,6 +430,7 @@ const eventTypes = [
     {id: "ECHO", name: "Echo", colour: "#9c2c46", search: /echo/i},
     {id: "OBSERVED", name: "Observed", colour: "#9a7b4f", search: /observed/i},
     {id: "SUNDIALED", name: "Sun Dialed", colour: "#ffe100", search: /catches some rays/i},
+    {id: "UNHOLEY", name: "Unholey", colour: "#863490", search: /compressed by gamma/i},
 
     {id: "CONSUMERS", name: "CONSUMERS", colour: "#c80c0c", search: /consumers/i},
     {id: "BREAK", name: "Item Broken", colour: "#6dc0ff", search: /broke|breaks/i},

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -337,7 +337,7 @@ events.on("gamesFinished",async (todaySchedule, tomorrowSchedule)=>{
 
 
 // // const lastPlay = new NodeCache({stdTTL: 60, checkperiod: 300});
-// const {Weather} = require("./util/gameUtils");
+// const {weatherCache} = require("blaseball");
 const {messageError} = require("./util/miscUtils");
 const {MessageEmbed} = require("discord.js");
 
@@ -367,7 +367,7 @@ const {MessageEmbed} = require("discord.js");
 //         } of ${
 //             game.seriesLength
 //         }\n> Weather: ${
-//             Weather[game.weather]
+//             (await weatherCache.fetch(game.weather)).name ?? "Uhhhh..."
 //         }\n`;
     
 

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -246,9 +246,9 @@ events.on("gameUpdate",async (newGame,oldGame)=>{
                     hometeamscore ? "**" : ""
                 }\n>>> ${
                     newGame.lastUpdate
-                }\n\`${
-                    newGame.scoreUpdate
-                }\``).then(global.stats.messageFreq.mark())).catch(messageError);
+                }${
+                    newGame.scoreUpdate ? "\n`" + newGame.scoreUpdate + "`" : ""
+                }`).then(global.stats.messageFreq.mark())).catch(messageError);
             }
         } catch (e) {
             console.error(e);
@@ -433,7 +433,7 @@ const eventTypes = [
     {id: "UNHOLEY", name: "Unholey", colour: "#863490", search: /compressed by gamma/i},
 
     {id: "CONSUMERS", name: "CONSUMERS", colour: "#c80c0c", search: /consumers/i},
-    {id: "BREAK", name: "Item Broken", colour: "#6dc0ff", search: /broke|breaks/i},
+    {id: "ITEMDAMAGE", name: "Item Damaged", colour: "#6dc0ff", search: /broke|breaks|damaged/i},
     {id: "SHAME", name: "SHAME", colour: "#800878", search: /shame/i},
     {id: "UNKNOWN", name: "Unknown Event", colour: "#010101"}
 ];

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -409,7 +409,7 @@ const {MessageEmbed} = require("discord.js");
 // }
 
 const eventTypes = [
-    {id: "REVERB", name: "Reverb", colour: "#61b3ff", search: /reverb|repeat/i},
+    {id: "REVERB", name: "Reverb", colour: "#5c407d", search: /reverb|repeat/i},
     {id: "FEEDBACK", name: "Feedback", colour: "#ff007b", search: /flicker|feedback/i},
     {id: "INCINERATION", name: "Incineration", colour: "#fefefe", search: /rogue umpire/i},
     {id: "PEANUT", name: "Peanut", colour: "#c4aa70", search: /stray peanut/i},
@@ -424,11 +424,12 @@ const eventTypes = [
     {id: "PERCOLATED", name: "Percolated", colour: "#96afd4", search: /percolated/i},
     {id: "HONEYROASTED", name: "Shelled", colour: "#ffda75", search: /tasted the infinite/i},
     {id: "ELSEWHERE", name: "Elsewhere", colour: "#bdb3c3", search: /elsewhere/i},
-    {id: "CONSUMERS", name: "CONSUMERS", colour: "#c80c0c", search: /consumers/i},
     {id: "ECHO", name: "Echo", colour: "#9c2c46", search: /echo/i},
     {id: "OBSERVED", name: "Observed", colour: "#9a7b4f", search: /observed/i},
     {id: "SUNDIALED", name: "Sun Dialed", colour: "#ffe100", search: /catches some rays/i},
 
+    {id: "CONSUMERS", name: "CONSUMERS", colour: "#c80c0c", search: /consumers/i},
+    {id: "BREAK", name: "Item Broken", colour: "#6dc0ff", search: /broke|breaks/i},
     {id: "SHAME", name: "SHAME", colour: "#800878", search: /shame/i},
     {id: "UNKNOWN", name: "Unknown Event", colour: "#010101"}
 ];

--- a/bot/util/gameUtils.js
+++ b/bot/util/gameUtils.js
@@ -1,54 +1,34 @@
 const { MessageEmbed } = require("discord.js");
 
+const { weatherCache } = require("blaseball");
 
-//PlayerCache
-
-
-const Weather = {
-    0: "Void",
-    1: "Sun 2",
-    2: "Overcast",
-    3: "Rainy",
-    4: "Sandstorm",
-    5: "Snowy",
-    6: "Acidic",
-    7: "Solar Eclipse",
-    8: "Glitter",
-    9: "Blooddrain",
-    10: "Peanuts",
-    11: "Bird",
-    12: "Feedback",
-    13: "Reverb",
-    14: "Black Hole",
-    15: "Coffee",
-    16: "Coffee 2",
-    17: "Coffee 3s",
-    18: "Flooding",
-    19: "Salmon"
-};
+const { emojiString } = require("./teamUtils");
 
 async function generateGameCard(gameInput){
     let game = {...gameInput};
     let winner;
     if(game.gameComplete){
-        winner = game.homeScore>game.awayScore ? game.homeTeamNickname : game.awayTeamNickname;
-    } else if(game.gameStart) winner = "[*Game in progress*](https://www.blaseball.com/)";
-    else winner = "[*Game yet to start*](https://www.blaseball.com/upcoming)";
+        winner = emojiString(game.homeScore>game.awayScore ? game.homeTeamEmoji : game.awayTeamEmoji) + " **" + (game.homeScore>game.awayScore ? game.homeTeamNickname : game.awayTeamNickname) + "**";
+    } else if(game.gameStart){
+        winner = "[*Game in progress*](https://www.blaseball.com/)";
+    } else {
+        winner = "[*Game yet to start*](https://www.blaseball.com/upcoming)";
+    }
     let shame = `SH${"A".repeat((Math.random()*5)+1)}${"M".repeat((Math.random()*5)+1)}${"E".repeat((Math.random()*5)+1)}${"!".repeat((Math.random()*5)+1)}`;
     let gameCard = new MessageEmbed()
-        .setTitle(`${Number(game.awayTeamEmoji)?String.fromCodePoint(game.awayTeamEmoji):game.awayTeamEmoji} __${game.awayTeamName}__ vs __${game.homeTeamName}__ ${Number(game.homeTeamEmoji)?String.fromCodePoint(game.homeTeamEmoji):game.homeTeamEmoji}\nSeason ${game.season+1} Day ${game.day+1}`)
+        .setTitle(`${emojiString(game.awayTeamEmoji)} __${game.awayTeamName}__ at __${game.homeTeamName}__ ${emojiString(game.homeTeamEmoji)}\nSeason ${game.season+1} Day ${game.day+1}`)
         .setColor(game.homeTeamColor)
         .setFooter(`Season: ${game.season+1} | Day: ${game.day+1}${game.shame?"\n"+shame:""}\nID: ${game.id}`)
         .addField(`${game.awayTeamNickname} Odds`, Math.round(game.awayOdds*100)+"%",true)
         .addField(`${game.homeTeamNickname} Odds`, Math.round(game.homeOdds*100)+"%",true)
         .addField("Game",`${game.seriesIndex} of ${game.seriesLength}`,true)
-        .addField(`${game.awayTeamNickname} Pitcher`,game.awayPitcherName||"Undecided", true)
-        .addField(`${game.homeTeamNickname} Pitcher`,game.homePitcherName||"Undecided", true)
+        .addField(`${game.awayTeamNickname} Pitcher`,game.awayPitcherName||"*Undecided*", true)
+        .addField(`${game.homeTeamNickname} Pitcher`,game.homePitcherName||"*Undecided*", true)
         .addField("Winner",winner,true)
         .addField(`${game.awayTeamNickname} Score`, game.awayScore, true)
         .addField(`${game.homeTeamNickname} Score`, game.homeScore, true)
-        .addField("Inning", game.gameStart?`${game.topOfInning?"Top":"Bottom"} of inning ${game.inning+1}`:"*Game yet to start*")
-        .addField("Weather", Weather[game.weather]??"Uhhhh...", true);
+        .addField("Inning", game.gameStart?`${game.topOfInning?"Top":"Bottom"} of inning ${game.inning+1}`:"*Game yet to start*");
+    if(game.season != 0) gameCard.addField("Weather", (await weatherCache.fetch(game.weather)).name ?? "Uhhhh...", true);
 
     if(game.shame)game.outcomes.push(`The ${game.homeScore>game.awayScore?game.awayTeamNickname:game.homeTeamNickname} were shamed!`);
 
@@ -59,6 +39,5 @@ async function generateGameCard(gameInput){
 
 
 module.exports = {
-    generateGameCard: generateGameCard,
-    Weather: Weather
+    generateGameCard: generateGameCard
 };

--- a/bot/util/gameUtils.js
+++ b/bot/util/gameUtils.js
@@ -12,7 +12,7 @@ const Weather = {
     4: "Sandstorm",
     5: "Snowy",
     6: "Acidic",
-    7: "Eclipse",
+    7: "Solar Eclipse",
     8: "Glitter",
     9: "Blooddrain",
     10: "Peanuts",

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -9,7 +9,7 @@ const {coffeeCache, bloodCache} = require("blaseball");
 async function generatePlayerCard(player, forbidden){
     let team = await getTeam(player.leagueTeamId || player.tournamentTeamId || PlayerTeams.get(player.id));
     let playerCard = new MessageEmbed()
-        .setTitle(emojiString(team.emoji) + " " + player.name + (player.permAttr.includes("SHELLED")?" 🥜":""))
+        .setTitle(emojiString(team.emoji) + " " + player.name + (player.permAttr.includes("SHELLED")?" 🥜":"") + (player.deceased ? " 💀" : ""))
         .setColor(team.mainColor)
         .setURL("https://www.blaseball.com/player/" + player.id)
         .addField("Team", emojiString(team.emoji) + " " + team.fullName + (team.fullName != "Null Team" ? " (" + getPosition(team, player) + ")" : ""), true);

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -11,6 +11,7 @@ async function generatePlayerCard(player, forbidden){
     let playerCard = new MessageEmbed()
         .setTitle((Number(team.emoji)?String.fromCodePoint(team.emoji):team.emoji) + " " + player.name + (player.permAttr.includes("SHELLED")?" 🥜":""))
         .setColor(team.mainColor)
+        .setURL("https://www.blaseball.com/player/" + player.id)
         .addField("Team", team.fullName, true)
         .addField("Position", getPosition(team, player), true);
     if(forbidden) playerCard.addField("Fingers", "||" + player.totalFingers + " Fingers||", true);

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -14,7 +14,7 @@ async function generatePlayerCard(player, forbidden){
         .addField("Team", team.fullName, true)
         .addField("Position", getPosition(team, player), true);
     if(forbidden) playerCard.addField("Fingers", "||" + player.totalFingers + " Fingers||", true);
-    if(forbidden) playerCard.addField("eDensity", "||" + player.eDensity.toFixed(5) + "||", true);
+    if(forbidden) playerCard.addField("eDensity", "||" + player.eDensity.toFixed(5) + " bl/m³||", true);
     playerCard.addField("Current Vibe", (player.permAttr.includes("SCATTERED") ? (forbidden ? "||" + vibeString(vibes(player)) + "||" : "** **") : vibeString(vibes(player))), true)
         .addField("Evolution", ((player.evolution > 0 && player.evolution < 4) ? "**Base " + player.evolution + "**" : (player.evolution == 4 ? "Home" : "Base")), true)
         .addField("Peanut Allergy", player.peanutAllergy?"Yes":"No", true)

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -35,12 +35,12 @@ async function generatePlayerCard(player, forbidden){
     return playerCard;
 }
 
-function ratingString(player, type) {
+function ratingString(player, statCategory) {
     let itemBoost = 0;
     for(const item of player.items){
-        itemBoost += item[type + "Rating"];
+        if(item.health > 0) itemBoost += item[statCategory + "Rating"];
     }
-    return stars(player[type + "Rating"] + itemBoost) + " (" + (player[type + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + (itemBoost * 5).toFixed(1) : "") + ")";
+    return stars(player[statCategory + "Rating"] + itemBoost) + " (" + (player[statCategory + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + (itemBoost * 5).toFixed(1) : "") + ")";
 }
 
 /*
@@ -196,6 +196,7 @@ function items(player){
 }
 
 function healthString(durability, health){
+    if(durability === -1) return "**∞**";
     // \u26ab - MEDIUM BLACK CIRCLE
     // \u26aa - MEDIUM WHITE CIRCLE
     // \ufe0e - VARIATION SELECTOR-15 (forces text presentation instead of emoji)

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -17,16 +17,16 @@ async function generatePlayerCard(player, forbidden){
         let tourneyTeam = await getTeam(player.tournamentTeamId);
         playerCard.addField("Tournament Team", emojiString(tourneyTeam.emoji) + " " + tourneyTeam.fullName + " (" + getPosition(tourneyTeam, player) + ")", true);
     }
-    if(forbidden) playerCard.addField("Fingers", "||" + player.totalFingers + " Fingers||", true);
-    if(forbidden) playerCard.addField("eDensity", "||" + player.eDensity.toFixed(5) + " bl/m³||", true);
     playerCard.addField("Current Vibe", (player.permAttr.includes("SCATTERED") ? (forbidden ? "||" + vibeString(vibes(player)) + "||" : "** **") : vibeString(vibes(player))), true)
         .addField("Evolution", ((player.evolution > 0 && player.evolution < 4) ? "**Base " + player.evolution + "**" : (player.evolution == 4 ? "Home" : "Base")), true)
         .addField("Peanut Allergy", player.peanutAllergy?"Yes":"No", true)
         .addField("Pregame Ritual", player.ritual || "** **", true)
-        .addField("Coffee Style", player.coffee ? (player.coffee == 7 ? "Espresso" : (await coffeeCache.fetch(player.coffee))) : "Coffee?", true)
-        .addField("Blood Type", player.blood ? (await bloodCache.fetch(player.blood)) : "Blood?", true)
+        .addField("Coffee Style", player.coffee !== null ? (player.coffee == 7 ? "Espresso" : (await coffeeCache.fetch(player.coffee))) : "Coffee?", true)
+        .addField("Blood Type", player.blood !== null ? (await bloodCache.fetch(player.blood)) : "Blood?", true)
         .addField("Fate", player.fate??"A roll of the dice", true)
-        .addField((player.permAttr.includes("RETIRED")) ? "Soulsong" : "Soulscream", soulscreamString(soulscream(player), player.soul, forbidden), false)
+    if(forbidden) playerCard.addField("Fingers", "||" + player.totalFingers + " Fingers||", true);
+    if(forbidden) playerCard.addField("eDensity", "||" + player.eDensity.toFixed(5) + " bl/m³||", true);
+    playerCard.addField((player.permAttr.includes("RETIRED")) ? "Soulsong" : "Soulscream", soulscreamString(soulscream(player), player.soul, forbidden), false)
         .addField("Items", items(player), true)
         .addField("Modifications", await attributes(player), true)
         .addField("**--Stars--**","** **", false)

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -27,20 +27,20 @@ async function generatePlayerCard(player, forbidden){
         .addField("Items", items(player), true)
         .addField("Modifications", await attributes(player), true)
         .addField("**--Stars--**","** **", false)
-        .addField("Batting", ratingString(player, "hitting"))
-        .addField("Pitching", ratingString(player, "pitching"))
-        .addField("Baserunning", ratingString(player, "baserunning"))
-        .addField("Defense", ratingString(player, "defense"))
+        .addField("Batting", ratingString(player, "hitting", player.evolution))
+        .addField("Pitching", ratingString(player, "pitching", player.evolution))
+        .addField("Baserunning", ratingString(player, "baserunning", player.evolution))
+        .addField("Defense", ratingString(player, "defense", player.evolution))
         .setFooter(`${team.slogan} | ID: ${player.id}`);
     return playerCard;
 }
 
-function ratingString(player, statCategory) {
+function ratingString(player, statCategory, evolution=0) {
     let itemBoost = 0;
     for(const item of player.items){
         if(item.health > 0) itemBoost += item[statCategory + "Rating"];
     }
-    return stars(player[statCategory + "Rating"] + itemBoost) + " (" + (player[statCategory + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + (itemBoost * 5).toFixed(1) : "") + ")";
+    return stars(player[statCategory + "Rating"] + itemBoost, evolution) + " (" + (player[statCategory + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + (itemBoost * 5).toFixed(1) : "") + ")";
 }
 
 /*
@@ -75,12 +75,14 @@ function baserunningRating(player){
 }
 */
 
-function stars(rating){
+function stars(rating, evolution){
     let stars = 0.5 * Math.round(10*rating);
 
     let starsString = "";
+    if(evolution > 0) starsString += "__";
     for (let index = 0; index < Math.floor(stars); index++) {
         starsString += "★";
+        if(index == evolution - 1) starsString += "__";
     }
     if(stars != Math.floor(stars)){
         starsString += "☆";

--- a/bot/util/playerUtils.js
+++ b/bot/util/playerUtils.js
@@ -43,7 +43,7 @@ function ratingString(player, statCategory) {
     for(const item of player.items){
         if(item.health > 0) itemBoost += item[statCategory + "Rating"];
     }
-    return stars(player[statCategory + "Rating"] + itemBoost, player.evolution) + " (" + (player[statCategory + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + (itemBoost * 5).toFixed(1) : "") + ")";
+    return stars(player[statCategory + "Rating"] + itemBoost, player.evolution) + " (" + (player[statCategory + "Rating"] * 5).toFixed(1) + ((itemBoost * 5).toFixed(1) != 0 ? (itemBoost > 0 ? " + " : " - ") + Math.abs(itemBoost * 5).toFixed(1) : "") + ")";
 }
 
 /*

--- a/bot/util/teamUtils.js
+++ b/bot/util/teamUtils.js
@@ -22,21 +22,30 @@ async function generateTeamCard(team, forbidden){
     let standings = games().standings;
     let wins = standings.wins[team.id] ?? 0;
     let losses = standings.losses[team.id] ?? 0;
+    let gamesPlayed = standings.gamesPlayed[team.id] ?? 0;
+    let runs = standings.runs[team.id] ?? 0;
+
     let teamCard = new MessageEmbed()
         .setTitle((Number(team.emoji)?String.fromCodePoint(team.emoji):team.emoji) + " " + team.fullName)
         .setColor(team.mainColor)
-        .addField("Lineup",team.lineup.length?playerList(team.lineup):"uhhhhh...",true)
-        .addField("Rotation",team.rotation.length?playerList(team.rotation):"uhhhhh...",true);
-    if(forbidden) teamCard.addField("Bullpen", team.bullpen.length?"||"+playerList(team.bullpen)+"||":"uhhhhh...",true)
-        .addField("Bench", team.bench.length?"||"+playerList(team.bench)+"||":"uhhhhh...", true);
-    teamCard.addField("Championships",team.championships, true)
-        .addField("Attributes", await attributes(team)||"None",true)
+        .setURL("https://www.blaseball.com/team/" + team.id)
+        .addField("Lineup",team.lineup.length?playerList(team.lineup):"*Empty*",true)
+        .addField("Rotation",team.rotation.length?playerList(team.rotation):"*Empty*",true);
+    if(forbidden) teamCard.addField("Shadow Lineup (Bullpen)", team.bullpen.length ? "||" + playerList(team.bullpen) + "||" : "||*Empty*||", true)
+        .addField("Shadow Rotation (Bench)", team.bench.length ? "||" + playerList(team.bench) + "||" : "||*Empty*||", true);
+    teamCard.addField("Modifications", await attributes(team)||"None",true)
+        .addField("Level", creditLevels[team.level] || "-", true)
+        .addField("eDensity", team.eDensity.toFixed(5) + " bl/m³", true)
+        .addField("Tarot Card", tarotCards[team.card] || "---- -----", true)
+        .addField("Championships","🟡".repeat(team.championships) || "** **", true)
+        .addField("Times Evolved", team.evolution, true)
         .addField("Been Shamed",team.totalShames, true)
         .addField("Shamed Others",team.totalShamings,true)
+        .addField("Runs This Season", runs, true)
         .addField("Been Shamed This Season", team.seasonShames, true)
         .addField("Shamed Others This Season", team.seasonShamings, true)
-        .addField("Win-Loss",`${wins}-${losses}`)
-        .setFooter(`${team.slogan} | ID: ${team.id}`);
+        .addField("Season Record",`${wins} Wins (${gamesPlayed - losses}-${losses})`)
+        .setFooter(`${team.slogan} | ${team.shorthand} | ID: ${team.id}`);
     return teamCard;
 }
 
@@ -84,9 +93,48 @@ const nullTeam = {
     slogan: "I AM ERROR"
 };
 
+const tarotCards = {
+    '-1': "Fool",
+    0: "I The Magician",
+    1: "II The High Priestess",
+    2: "III The Empress",
+    3: "IIII The Emperor",
+    4: "V The Hierophant",
+    5: "VI The Lover",
+    6: "VII The Chariot",
+    7: "VIII Justice",
+    8: "VIIII The Hermit",
+    9: "X The Wheel of Fortune",
+    10: "XI Strength",
+    11: "XII The Hanged Man",
+    12: "XIII",
+    13: "XIIII Temperance",
+    14: "XV The Devil",
+    15: "XVI The Tower",
+    16: "XVII The Star",
+    17: "XVIII The Moon",
+    18: "XVIIII The Sun",
+    19: "XX Judgment"
+}
+
+const creditLevels = {
+    0: "0D",
+    1: "1D",
+    2: "2D",
+    3: "3D",
+    4: "C",
+    5: "Low A",
+    6: "High A",
+    7: "AA",
+    8: "AAA",
+    9: "AAAA",
+    10: "AAAAA"
+}
 
 module.exports = {
     getTeam: getTeam,
     generateTeamCard: generateTeamCard,
-    nullTeam:nullTeam
+    nullTeam: nullTeam,
+    tarotCards: tarotCards,
+    creditLevels: creditLevels
 };

--- a/bot/util/teamUtils.js
+++ b/bot/util/teamUtils.js
@@ -8,13 +8,13 @@ const { MessageEmbed } = require("discord.js");
 async function getTeam(name){
     if(name == undefined) return nullTeam;
     let team = name?TeamCache.get(name):nullTeam;
-    if(!team || team.fullName == "Null Team"){
+    if(!team || team.fullName == nullTeam.fullName){
         let nameLowercase = name.toLowerCase();
         let teamName = TeamNames.findKey(team => (team.lowercase == nameLowercase || team.location == nameLowercase || team.nickname == nameLowercase || team.shorthand == nameLowercase || team.emoji == nameLowercase));
         if(!teamName) return null;
         team = TeamCache.get(teamName);
     }
-    if(!team || team.fullName == "Null Team") return null;
+    if(!team || team.fullName == nullTeam.fullName) return null;
     else return team;
 }
 
@@ -26,13 +26,13 @@ async function generateTeamCard(team, forbidden){
     let runs = standings.runs[team.id] ?? 0;
 
     let teamCard = new MessageEmbed()
-        .setTitle((Number(team.emoji)?String.fromCodePoint(team.emoji):team.emoji) + " " + team.fullName)
+        .setTitle(emojiString(team.emoji) + " " + team.fullName)
         .setColor(team.mainColor)
         .setURL("https://www.blaseball.com/team/" + team.id)
         .addField("Lineup",team.lineup.length?playerList(team.lineup):"*Empty*",true)
         .addField("Rotation",team.rotation.length?playerList(team.rotation):"*Empty*",true);
-    if(forbidden) teamCard.addField("Shadow Lineup (Bullpen)", team.bullpen.length ? "||" + playerList(team.bullpen) + "||" : "||*Empty*||", true)
-        .addField("Shadow Rotation (Bench)", team.bench.length ? "||" + playerList(team.bench) + "||" : "||*Empty*||", true);
+    if(forbidden) teamCard.addField("Bullpen", team.bullpen.length ? "||" + playerList(team.bullpen) + "||" : "||*Empty*||", true)
+        .addField("Bench", team.bench.length ? "||" + playerList(team.bench) + "||" : "||*Empty*||", true);
     teamCard.addField("Modifications", await attributes(team)||"None",true)
         .addField("Level", creditLevels[team.level] || "-", true)
         .addField("eDensity", team.eDensity.toFixed(5) + " bl/m³", true)
@@ -131,10 +131,15 @@ const creditLevels = {
     10: "AAAAA"
 }
 
+function emojiString(emoji) {
+    return Number(emoji) ? String.fromCodePoint(emoji) : emoji;
+}
+
 module.exports = {
     getTeam: getTeam,
     generateTeamCard: generateTeamCard,
     nullTeam: nullTeam,
     tarotCards: tarotCards,
-    creditLevels: creditLevels
+    creditLevels: creditLevels,
+    emojiString: emojiString
 };

--- a/bot/util/teamUtils.js
+++ b/bot/util/teamUtils.js
@@ -33,7 +33,7 @@ async function generateTeamCard(team, forbidden){
         .addField("Rotation",team.rotation.length?playerList(team.rotation):"*Empty*",true);
     if(forbidden) teamCard.addField("Bullpen", team.bullpen.length ? "||" + playerList(team.bullpen) + "||" : "||*Empty*||", true)
         .addField("Bench", team.bench.length ? "||" + playerList(team.bench) + "||" : "||*Empty*||", true);
-    teamCard.addField("Modifications", await attributes(team)||"None",true)
+    teamCard.addField("Modifications", await attributes(team), true)
         .addField("Level", creditLevels[team.level] || "-", true)
         .addField("eDensity", team.eDensity.toFixed(5) + " bl/m³", true)
         .addField("Tarot Card", tarotCards[team.card] || "---- -----", true)
@@ -70,7 +70,7 @@ async function attributes(team){
         let attr = await modCache.fetch(attribute);
         attrString += (attr.title) +" (Day)\n";
     }
-    return attrString || "None";
+    return attrString || "*None*";
 }
 
 function playerList(players){


### PR DESCRIPTION
Plus other miscellaneous changes. This should probably have been multiple pull requests, but ah well.

- Events and score updates (`gameUpdates.js`):
  - Add `ITEMDAMAGE`, `SALMON`, `GLITTER`, and `UNHOLEY` event types.
  - Change Reverb colour to purple (colour picked from icon) to distinguish from item damage colour.
  - When sending a score update message, do not print backticks on the last line unless there is actually a scoreUpdate message to go between them.
- Team cards (`teamUtils.js`):
  - Link the team name to the team's page on the site.
  - Add Level, eDensity, Tarot Card, Times Evolved, and Runs. Still no Ballparks, since there doesn't seem to be an endpoint for that?
  - Replace Championships number with yellow dots, to match the site.
  - Rename Attributes -> Modifications and Win-Loss -> Season Record.
  - Add Wins to season record and correct the record to match the site (ie. first number is games won, not Wins).
  - Add team shorthand to embed footer.
- Player cards (`playerUtils.js`):
  - Link the player name to the player's page on the site.
  - Add a skull emoji 💀 after the player's name if they are deceased.
  - Add position (within team - depends on the cached team object, so may be slightly out of date compared to the player object), tournament team (if present), tournament team position, Evolution, eDensity (FK), and Soul (FK).
  - Un-forbid Peanut Allergy.
  - Remove Item/Armor fields. Add Items field (showing slots, item names, durability, and health) and item attributes.
  - Underline gilded evolution stars.
  - Switch to using the ratings straight from the database instead of calculating them from stlats.
  - Display star values and item adjustments in brackets beside the stars.
  - Rename, reorder, and format several fields to better match the site. The Soulscream label is now changed to Soulsong if the player is Released.
  - Hide Current Vibe if player is Scattered, unless FK is enabled in which case it's only spoilered.
  - Fix bug with tournament teams occasionally being shown instead of league teams by switching to using the player object's `leagueTeamId` and `tournamentTeamId` properties. The `PlayerTeams` cache isn't really used anymore as a result; I _assume_ it can be disposed of, but I'm not touching it myself just in case.
  - Fix multi-codepoint emoji being displayed as 'undefined'.
  - Fix soulscream field for soulless players.
  - Fix soulscream formula.
  - Fix 'Espresso' and 'Black' being displayed as "Coffee?", fix 'A' being displayed as "Blood?".
- Game cards (`gameUtils.js`):
  - Refactor to use `node-blaseball`'s `weatherCache` instead of the `Weather` object.
  - Switch title format from "[team] vs [team]" to "[team] at [team]" to better show which team is home/away (as well as to better match conventions in real life sports).
  - Add team emoji to Winner field, embolden winner name. Other minor formatting changes.
  - Hide the Weather field if the game is in Season 1.

I also took a few [example screenshots of the updated team and player cards](https://imgur.com/a/YEpPLKO), for convenience. (Edit: These images are now slightly outdated; the FK stats on player cards are now placed after Fate.)