### PR TITLE
Rename the purple-text entity to "The Reader"

### DIFF
--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -56,7 +56,7 @@ async function screenTakeover (temporal) {
     };
         break;
     case 3: speak = {
-        "name": "Tarot Draw",
+        "name": "The Reader",
         "colour": "#a16dc3",
         "url": ""
     };
@@ -421,7 +421,6 @@ const eventTypes = [
         "name": "Glitter",
         "colour": "#ff94ff",
         "search": /gained/iu},
-
     {"id": "UNSTABLE",
         "name": "Unstable",
         "colour": "#eaabff",
@@ -469,7 +468,7 @@ const eventTypes = [
     {"id": "ITEMDAMAGE",
         "name": "Item Damaged",
         "colour": "#6dc0ff",
-        "search": /broke|breaks|damaged/iu},
+        "search": /broke|break|damaged/iu},
     {"id": "FAX",
         "name": "Fax Machine",
         "colour": "#C0C0C0",


### PR DESCRIPTION
This is a small tweak to change the purple-text entity's name from "Tarot Draw" to "The Reader" (based on Lootcrates seeming to use this name for them in S17's earlsiesta, and the fact that "Tarot Draw" no longer makes sense for them as a name since they will no longer be doing the seasonal tarot draw).

This PR also fixes events like "SUNGLASSES BREAK" not being registered as item damage events.