### PR TITLE
Fix zero-run scoring plays not being sent to subscribed channels

### DIFF
--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -162,7 +162,7 @@ events.on("gameUpdate", async (newGame, oldGame) => {
         return;
 
     }
-    if (oldGame.homeScore !== newGame.homeScore || oldGame.awayScore !== newGame.awayScore) {
+    if (oldGame.homeScore !== newGame.homeScore || oldGame.awayScore !== newGame.awayScore || newGame.scoreUpdate?.length > 0) {
 
         try {
 
@@ -185,6 +185,7 @@ events.on("gameUpdate", async (newGame, oldGame) => {
 
             for (const compactSubscription of docs) {
 
+                // Anti double posting
                 if (
                     compactSubscription.team === newGame.awayTeam
                     && docs.find((doc) => doc.team === newGame.homeTeam
@@ -193,8 +194,9 @@ events.on("gameUpdate", async (newGame, oldGame) => {
                     continue;
 
                 }
-                // Anti double posting
+
                 const hometeamscore = oldGame.homeScore !== newGame.homeScore;
+                const awayteamscore = oldGame.awayScore !== newGame.awayScore;
 
                 client.channels.fetch(compactSubscription.channel_id)
                     .then((channel) => channel.send(`**${
@@ -208,11 +210,11 @@ events.on("gameUpdate", async (newGame, oldGame) => {
                             ? String.fromCodePoint(newGame.awayTeamEmoji)
                             : newGame.awayTeamEmoji
                     } ${
-                        !hometeamscore ? "**" : ""
+                        awayteamscore ? "**" : ""
                     }${
                         newGame.awayScore
                     }${
-                        !hometeamscore ? "**" : ""
+                        awayteamscore ? "**" : ""
                     } ${
                         Number(newGame.homeTeamEmoji)
                             ? String.fromCodePoint(newGame.homeTeamEmoji)

--- a/bot/gameUpdates.js
+++ b/bot/gameUpdates.js
@@ -162,7 +162,9 @@ events.on("gameUpdate", async (newGame, oldGame) => {
         return;
 
     }
-    if (oldGame.homeScore !== newGame.homeScore || oldGame.awayScore !== newGame.awayScore || newGame.scoreUpdate?.length > 0) {
+    if (oldGame.homeScore !== newGame.homeScore
+        || oldGame.awayScore !== newGame.awayScore
+        || newGame.scoreUpdate?.length > 0) {
 
         try {
 


### PR DESCRIPTION
Small PR to fix zero-run scoring plays ([which can happen thanks to unrun weirdness](https://cdn.discordapp.com/attachments/750322917396578364/854698971325661194/unknown.png)) not being sent to channels subscribed to score updates. This PR also changes the score highlight logic to allow for the possibility of both the home and away scores changing at the same time (I'm not sure if that's ever happened, but it definitely can't be ruled out – this is Blaseball, after all).

(Update, just a day after opening this PR: Both teams' scores changing simultaneously is now happening, thanks to Tunnels. Wild.)