### PR TITLE
Fix game cards erroring if the weather can't be found

### DIFF
--- a/bot/util/gameUtils.js
+++ b/bot/util/gameUtils.js
@@ -81,7 +81,7 @@ async function generateGameCard (gameInput) {
 
         gameCard.addField(
             "Weather",
-            (await weatherCache.fetch(game.weather)).name ?? "Uhhhh...", true
+            (await weatherCache.fetch(game.weather))?.name ?? "Uhhhh...", true
         );
 
     }


### PR DESCRIPTION
Small fix to prevent game cards from erroring if the weather cache doesn't include the game's weather.